### PR TITLE
remove explicit http:

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -17,7 +17,7 @@
 	
     {{! Styles }}
 	<link href='//fonts.googleapis.com/css?family=Lato:300,400,700|Oxygen:400,700' rel='stylesheet' type='text/css'>
-	<link href='http://fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
 	<link href="//netdna.bootstrapcdn.com/font-awesome/4.0.0/css/font-awesome.min.css" rel="stylesheet">
 	
     


### PR DESCRIPTION
remove explicit http: to avoid unnecessary security warnings when the blog is running behind https
